### PR TITLE
using compat from this package

### DIFF
--- a/rest_framework_oauth/authentication.py
+++ b/rest_framework_oauth/authentication.py
@@ -8,8 +8,8 @@ from django.conf import settings
 
 from rest_framework import exceptions
 from rest_framework.authentication import get_authorization_header, BaseAuthentication
-from rest_framework.compat import oauth, oauth_provider, oauth_provider_store
-from rest_framework.compat import oauth2_provider, provider_now, check_nonce
+from compat import oauth, oauth_provider, oauth_provider_store
+from compat import oauth2_provider, provider_now, check_nonce
 
 
 class OAuthAuthentication(BaseAuthentication):


### PR DESCRIPTION
Since relevant compat.py contents were copied to to this repo and removed from drf 3.1.