### PR TITLE
Oauth packages should be optional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-django-oauth-plus>=2.2.1
-oauth2>=1.5.211
-django-oauth2-provider>=0.2.4
+


### PR DESCRIPTION
In most cases we only need one of these packages. installing django-rest-framework-oauth will have them all installed.