### PR TITLE
Make OAuth packages optional

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,9 +17,9 @@ OAuth support for Django REST Framework
 
 ## Overview
 
-OAuth support extracted as a third party package directly from the official Django REST Framework implementation. It's built using the [django-oauth-plus][django-oauth-plus] and [django-oauth2-provider][django-oauth2-provider] packages.
+OAuth support extracted as a third party package directly from the official Django REST Framework implementation. It's built to use the [django-oauth-plus][django-oauth-plus], [oauth2][oauth2], and [django-oauth2-provider][django-oauth2-provider] packages.
 
-This package provides two authentication classes: [OAuthAuthentication][oauth-authentication] and [OAuth2Authentication][oauth2-authentication] and a [TokenHasReadWriteScope][token-has-read-write-scope] permission class.
+This package provides two authentication classes, [OAuthAuthentication][oauth-authentication] and [OAuth2Authentication][oauth2-authentication], and a [TokenHasReadWriteScope][token-has-read-write-scope] permission class.
 
 ## Requirements
 
@@ -29,11 +29,25 @@ This package provides two authentication classes: [OAuthAuthentication][oauth-au
 
 ## Installation
 
-Install using `pip`...
+Install using `pip`:
 
 ```bash
 $ pip install djangorestframework-oauth
 ```
+
+OAuth packages are optional and not installed out of the box. Use of `OAuthAuthentication` requires installation of the `django-oauth-plus` and `oauth2` packages:
+
+```bash
+$ pip install django-oauth-plus oauth2
+```
+
+Use of `OAuth2Authentication` requires installation of `django-oauth2-provider`:
+
+```bash
+$ pip install django-oauth2-provider
+```
+
+Use of `TokenHasReadWriteScope` requires installation of either `django-oauth-plus` or `django-oauth2-provider`.
 
 ## Documentation & Support
 
@@ -46,7 +60,6 @@ You may also want to follow the [author][jpadilla] on Twitter.
 Install testing requirements.
 
 ```bash
-$ pip install -r requirements.txt
 $ pip install -r requirements-test.txt
 ```
 
@@ -87,5 +100,6 @@ $ mkdocs build
 [oauth2-authentication]: authentication.md#oauth2authentication
 [token-has-read-write-scope]: permissions.md#tokenhasreadwritescope
 [django-oauth-plus]: http://code.larlet.fr/django-oauth-plus/wiki/Home
+[oauth2]: https://github.com/joestump/python-oauth2
 [django-oauth2-provider]: http://django-oauth2-provider.readthedocs.org/
 [jpadilla]: https://twitter.com/jpadilla_

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,9 @@
-Django>=1.6
+Django>=1.6,<1.8
 djangorestframework>=2.4.3
+django-oauth-plus>=2.2.1
+django-oauth2-provider>=0.2.4
+flake8==2.2.2
+oauth2==1.5.211
+pytest-cov==1.6
 pytest-django==2.6
 pytest==2.5.2
-pytest-cov==1.6
-flake8==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-django-oauth-plus>=2.2.1
-oauth2>=1.5.211
-django-oauth2-provider>=0.2.4

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ url = 'https://github.com/jpadilla/django-rest-framework-oauth'
 author = 'José Padilla'
 author_email = 'hello@jpadilla.com'
 license = 'BSD'
-install_requires = open('requirements.txt').read().split('\n')
 
 
 # This command has been borrowed from
@@ -88,7 +87,6 @@ setup(
     packages=get_packages(package),
     package_data=get_package_data(package),
     cmdclass={'test': PyTest},
-    install_requires=install_requires,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ deps =
        drf30: djangorestframework==3.0.0
        drf31: djangorestframework==3.1.0
        pytest-django==2.6.1
+       django-oauth-plus>=2.2.1
+       oauth2==1.5.211
+       django-oauth2-provider>=0.2.4
 
 [testenv:py27-flake8]
 commands = ./runtests.py --lintonly


### PR DESCRIPTION
In most cases, only one OAuth package is necessary. This PR is a successor to https://github.com/jpadilla/django-rest-framework-oauth/pull/8, which made a similar change but didn't fix tests.

@jpadilla could you please review this? Let me know if you have any questions.