### PR TITLE
remove unnecessary argument: request

### DIFF
--- a/rest_framework_oauth/authentication.py
+++ b/rest_framework_oauth/authentication.py
@@ -158,9 +158,9 @@ class OAuth2Authentication(BaseAuthentication):
         else:
             return None
 
-        return self.authenticate_credentials(request, access_token)
+        return self.authenticate_credentials(access_token)
 
-    def authenticate_credentials(self, request, access_token):
+    def authenticate_credentials(self, access_token):
         """
         Authenticate the request, given the access token.
         """


### PR DESCRIPTION
argument `request` is not used anywhere in `OAuth2Authentication.authenticate_credentials() `.

unused arguments can be removed.